### PR TITLE
Fix VDP1 rendering: OpenGL Y-flip and palette color lookups

### DIFF
--- a/AzelLib/processModel.cpp
+++ b/AzelLib/processModel.cpp
@@ -225,6 +225,8 @@ void sProcessed3dModel::generateVertexBuffer()
     }
 
     m_textureAtlas = bgfx::createTexture2D(atlasTextureWidth, atlasTextureHeight, false, 1, bgfx::TextureFormat::RGBA8, 0, bgfx::copy(&atlasTexture[0], atlasTextureWidth * atlasTextureHeight * 4));
+    m_textureAtlasWidth = atlasTextureWidth;
+    m_textureAtlasHeight = atlasTextureHeight;
 
     m_vertexBuffersDirty = false;
     m_vertexBuffer.resize(mC_Quads.size() * 4);

--- a/AzelLib/processModel.h
+++ b/AzelLib/processModel.h
@@ -62,6 +62,8 @@ struct sProcessed3dModel
     bgfx::VertexBufferHandle m_vertexBufferHandle = BGFX_INVALID_HANDLE;
     bgfx::IndexBufferHandle m_indexBufferHandle = BGFX_INVALID_HANDLE;
     bgfx::TextureHandle m_textureAtlas = BGFX_INVALID_HANDLE;
+    int m_textureAtlasWidth = 1;
+    int m_textureAtlasHeight = 1;
 
     bool m_vertexBuffersDirty = true;
 };

--- a/AzelLib/renderer.cpp
+++ b/AzelLib/renderer.cpp
@@ -1376,7 +1376,8 @@ void PolyLineDraw(s_vdp1Command* vdp1EA)
     }
     else
     {
-        finalColor = 0xFF0000FF;
+        u16 color = getVdp2CramU16(CMDCOLR * 2);
+        finalColor = 0xFF000000 | (((color & 0x1F) << 3) | ((color & 0x03E0) << 6) | ((color & 0x7C00) << 9));
     }
 
     drawLine(CMDXA + localCoordiantesX, CMDYA + localCoordiantesY, CMDXB + localCoordiantesX, CMDYB + localCoordiantesY, finalColor);


### PR DESCRIPTION
Fixes VDP1 (3D/sprite) rendering for OpenGL and corrects polygon/sprite colors that used wrong palette lookups.

## Files changed

### OpenGL culling fix
- **AzelLib/3dEngine_flush.cpp** (L292-304): Add helpers that swap cull winding on OpenGL (OpenGL and DirectX have opposite Y direction)
- **AzelLib/3dEngine_flush.cpp** (L335, L763, L927, L976, L1021, L1080, L1170): Use the new helpers in all draw calls instead of hardcoded cull state
- **AzelLib/3dEngine_flush.cpp** (L418-423): Flip projection Y-axis for OpenGL backend

### Texture atlas size tracking
- **AzelLib/3dEngine_flush.cpp** (L316, L322, L343-349): Pass texture atlas dimensions to the VDP1 shader as a uniform
- **AzelLib/processModel.cpp** (L227-228): Save atlas width/height after creating the texture
- **AzelLib/processModel.h** (L65-66): Add width/height fields to the 3D model struct

### Fix polygon/sprite colors
- **AzelLib/3dEngine_flush.cpp** (L1139-1162, L1198-1231): In polygon draw functions, look up palette colors from Color RAM instead of showing hardcoded blue
- **AzelLib/3dEngine_textureCache.cpp** (L125-148): In sprite texture decoding, resolve palette indices through Color RAM for correct colors
- **AzelLib/renderer.cpp** (L1571-1584): Same palette lookup fix in the software rendering path

## Merge note
Safe to merge on its own. These are standalone bug fixes - polygons and sprites that showed as solid blue will now show correct colors. Can go in any order with PRs 1 and 5.