### PR TITLE
Fix VDP2 background rendering pipeline

### DIFF
--- a/AzelLib/VDP2.cpp
+++ b/AzelLib/VDP2.cpp
@@ -385,7 +385,9 @@ void resetVdp2RegsCopy(s_VDP2Regs* pRegisters)
     pRegisters->m18_CYCB0 = 0xFFFF;
     pRegisters->m1C_CYCB1 = 0xFFFF;
     pRegisters->m78_ZMXN0 = 0x10000;
+    pRegisters->m7C_ZMYN0 = 0x10000;
     pRegisters->m88_ZMXN1 = 0x10000;
+    pRegisters->m8C_ZMYN1 = 0x10000;
     pRegisters->mE0_SPCTL = 0x20;
 }
 
@@ -1614,6 +1616,7 @@ s32 computeStringLength(const char* pString, s32 r5)
         }
         r14++;
     };
+    return r14;
 }
 
 void clearBlueBox(s32 x, s32 y, s32 width, s32 height)

--- a/AzelLib/renderer.h
+++ b/AzelLib/renderer.h
@@ -12,8 +12,9 @@ enum bgfxViews
     VDP2_NGB4,
     VDP2_MAX = VDP2_NGB4,
 
-    CompositeView,
+    // VDP1 must render BEFORE compositing
     vdp1_gpuView,
+    CompositeView,
 };
 
 void azelSdl2_Init();

--- a/AzelLib/shaders/VDP2_ps.sc
+++ b/AzelLib/shaders/VDP2_ps.sc
@@ -3,9 +3,9 @@
 #define u32 highp uint
 #define s32 highp int
 
-highp USAMPLER2D(s_VDP2_RAM, 0);
-highp USAMPLER2D(s_VDP2_CRAM, 1);
-highp USAMPLER2D(s_planeConfig, 2);
+USAMPLER2D(s_VDP2_RAM, 0);
+USAMPLER2D(s_VDP2_CRAM, 1);
+SAMPLER2D(s_planeConfig, 2);
 
 #define in_CHSZ readFromPanelConfig(0)
 #define in_CHCN readFromPanelConfig(1)
@@ -21,6 +21,8 @@ highp USAMPLER2D(s_planeConfig, 2);
 #define in_scrollX readFromPanelConfig(11)
 #define in_scrollY readFromPanelConfig(12)
 #define in_outputHeight readFromPanelConfig(13)
+#define in_zoomX readFromPanelConfig(15)
+#define in_zoomY readFromPanelConfig(16)
 
 struct s_layerData
 {
@@ -40,13 +42,10 @@ struct s_layerData
 
 int readFromPanelConfig(s32 offset)
 {
-    ivec2 position;
-    position.x = offset;
-    position.y = 0;
-    uvec4 texel = texelFetch(s_planeConfig, position, 0);
-    s32 texelValue = int(texel.r);
-
-    return texelValue;
+    vec4 texel = texelFetch(s_planeConfig, ivec2(offset, 0), 0);
+    uvec4 bytes = uvec4(texel * 255.0 + 0.5);
+    s32 value = int(bytes.x | (bytes.y << 8) | (bytes.z << 16) | (bytes.w << 24));
+    return value;
 }
 
 int readFromSampler_VDP2_RAM(s32 offset)
@@ -121,15 +120,15 @@ vec4 sampleLayer(int rawOutputX, int rawOutputY, s_layerData layerData)
     s32 outputX = rawOutputX + layerData.scrollX;
     s32 outputY = rawOutputY + layerData.scrollY;
 
-    if (outputX < 0)
-        return vec4(1,0,0,1);
-    if (outputY < 0)
-        return vec4(1,0,0,1);
+    // VDP2 scroll coordinates wrap around the map dimensions
+    // Use proper modulo that handles negative values
+    outputX = ((outputX % mapDotWidth) + mapDotWidth) % mapDotWidth;
+    outputY = ((outputY % mapDotHeight) + mapDotHeight) % mapDotHeight;
 
     int planeX = outputX / planeDotWidth;
     int planeY = outputY / planeDotHeight;
     int dotInPlaneX = outputX % planeDotWidth;
-    int dotInPlaneY = outputY % planeDotWidth;
+    int dotInPlaneY = outputY % planeDotHeight;
 
     int pageX = dotInPlaneX / pageDotDimension;
     int pageY = dotInPlaneY / pageDotDimension;
@@ -164,8 +163,21 @@ vec4 sampleLayer(int rawOutputX, int rawOutputY, s_layerData layerData)
         int patternName = getVdp2VramU16(startOfPattern);
         int supplementalCharacterName = layerData.SCN;
 
-        // assuming supplement mode 0 with no data
-        paletteNumber = (patternName >> 12) & 0xF;
+        // Palette number depends on color mode (CHCN), match CPU path in renderer.cpp
+        if (layerData.CHCN == 0)
+        {
+            // 16 colors (4bpp)
+            paletteNumber = (patternName >> 12) & 0xF;
+        }
+        else if (layerData.CHCN == 1)
+        {
+            // 256 colors (8bpp): bits 12-14 become high bits of palette offset
+            paletteNumber = (patternName & 0x7000) >> 8;
+        }
+        else
+        {
+            paletteNumber = 0;
+        }
 
         if(layerData.CNSM == 0)
         {
@@ -196,6 +208,8 @@ vec4 sampleLayer(int rawOutputX, int rawOutputY, s_layerData layerData)
             }
         }
 
+        // Character offset is always 0x20 (32 bytes) per character number unit
+        // Game data is organized with pattern numbers spaced correctly for different color modes
         characterOffset = (characterNumber) * 0x20;
     }
     else if(patternSize == 4)
@@ -211,7 +225,8 @@ vec4 sampleLayer(int rawOutputX, int rawOutputY, s_layerData layerData)
     }
     else
     {
-        return vec4(1,0,0,1);
+        // Invalid pattern size - return YELLOW for debug
+        return vec4(1,1,0,1);
     }
 
     int cellIndex = cellX + cellY * 2;
@@ -243,7 +258,8 @@ vec4 sampleLayer(int rawOutputX, int rawOutputY, s_layerData layerData)
             dotColor = getVdp2VramU8(dotOffset);
         }
         else
-            return vec4(1,0,0,1);
+            // Invalid CHCN - return CYAN for debug
+            return vec4(0,1,1,1);
     }
 
     if(dotColor != 0)
@@ -279,5 +295,10 @@ void main()
     inputLayerData.scrollX = in_scrollX;
     inputLayerData.scrollY = in_scrollY;
 
-    gl_FragColor = sampleLayer(int(gl_FragCoord.x), int(gl_FragCoord.y), inputLayerData);
+    // DEBUG: Uncomment to test shader is running
+    // gl_FragColor = vec4(0.5, 0.0, 0.5, 1.0); return;
+
+    int rawX = int(gl_FragCoord.x * float(in_zoomX) / 65536.0);
+    int rawY = int(gl_FragCoord.y * float(in_zoomY) / 65536.0);
+    gl_FragColor = sampleLayer(rawX, rawY, inputLayerData);
 }


### PR DESCRIPTION
Fixes VDP2 background layer rendering so layers display correctly at all resolutions.

## Files changed

### VDP2 shader
- **AzelLib/shaders/VDP2_ps.sc** (L6): Use regular sampler for plane config texture (was unsigned int sampler that broke on some drivers)
- **AzelLib/shaders/VDP2_ps.sc** (L42-48): Read config values as RGBA8 bytes and reconstruct ints (matches new texture format)
- **AzelLib/shaders/VDP2_ps.sc** (L120-127): Wrap scroll coordinates with modulo so negative scroll values work instead of showing red
- **AzelLib/shaders/VDP2_ps.sc** (L131): Fix Y-axis tile lookup - was using width instead of height
- **AzelLib/shaders/VDP2_ps.sc** (L163-185): Pick correct palette based on color depth (16-color vs 256-color modes)
- **AzelLib/shaders/VDP2_ps.sc** (L295-299): Apply zoom/scale to pixel coordinates

### Layer data and GPU rendering
- **AzelLib/renderer.cpp** (L540-564): Add zoom and output height fields to layer config struct
- **AzelLib/renderer.cpp** (L582-590): Recreate GPU framebuffer when switching between GPU and software mode
- **AzelLib/renderer.cpp** (L617): Change config texture format from R32U to RGBA8 (works on all backends)
- **AzelLib/renderer.cpp** (L632-697): Pass all layer settings as GPU uniforms so the shader can read them reliably

### Software rendering path
- **AzelLib/renderer.cpp** (new, ~L743-775): New `renderLayerSoftware()` function - renders on CPU and uploads to GPU texture. Replaces `assert(0)` that crashed when software mode was selected.
- **AzelLib/renderer.cpp** (L813-816): Apply zoom in software renderer too

### Per-layer fixes (BG0, BG1, BG3, RBG0)
- **AzelLib/renderer.cpp** `renderBG0` (L988-1004): Remove duplicate resolution doubling, add zoom registers, use new software path
- **AzelLib/renderer.cpp** `renderBG1` (L1104-1163): Add zoom registers, use new software path
- **AzelLib/renderer.cpp** `renderBG3` (L1226-1240): Add output height, use new software path
- **AzelLib/renderer.cpp** `renderRBG0` (L1307-1323): Add output height, use new software path

### Compositing (final image assembly)
- **AzelLib/renderer.cpp** (L1808-1812): Enable alpha blending when drawing layers, stop clearing between each layer
- **AzelLib/renderer.cpp** (L1854-1870): Handle all 8 HRESO resolution modes. Split VDP1 (3D) resolution from VDP2 (background) resolution - title screen needs 352px for 3D but 704px for backgrounds
- **AzelLib/renderer.cpp** (L1998-2040): Use the back screen color register for clear color. Draw sprites at their priority level, then backgrounds in order

### Supporting fixes
- **AzelLib/renderer.h** (L15-17): Reorder views so VDP1 renders before the composite pass
- **AzelLib/VDP2.cpp** (L418-419): Init zoom Y registers to 1.0 (was uninitialized)
- **AzelLib/VDP2.cpp** (L1759): Fix missing return in `computeStringLength()`

## Merge note
Safe to merge on its own. This is the biggest PR but all changes are self-consistent - the shader, texture format, and renderer code all match each other. Recommend merging this before PR 4 (title screen text), since the text layer needs these rendering fixes to actually show up.