### PR TITLE
Fix title screen text and palette rendering

### DIFF
--- a/AzelLib/VDP2.cpp
+++ b/AzelLib/VDP2.cpp
@@ -943,11 +943,81 @@ void copyFontToVdp2()
 
 void setFontDefaultColor(u32 paletteIndex, u16 color0, u16 color1)
 {
+    u8* paletteBase = vdp2FontPalettes + paletteIndex * 32;
 
+    int r0 = color0 & 0x1F;
+    int g0 = (color0 >> 5) & 0x1F;
+    int b0 = (color0 >> 10) & 0x1F;
+    int r1 = color1 & 0x1F;
+    int g1 = (color1 >> 5) & 0x1F;
+    int b1 = (color1 >> 10) & 0x1F;
+
+    for (int i = 0; i < 16; i++)
+    {
+        u16 color;
+        if (i == 0)
+        {
+            color = 0x0000;
+        }
+        else if (i <= 7)
+        {
+            color = color1;
+        }
+        else
+        {
+            int t = i - 8;
+            int r = r0 + (r1 - r0) * t / 7;
+            int g = g0 + (g1 - g0) * t / 7;
+            int b = b0 + (b1 - b0) * t / 7;
+            color = (u16)((b << 10) | (g << 5) | r);
+        }
+
+        paletteBase[i * 2] = (color >> 8) & 0xFF;
+        paletteBase[i * 2 + 1] = color & 0xFF;
+    }
+}
+
+void setFontPaletteGradient(u32 paletteIndex, u16 bodyColor, u16 borderColor)
+{
+    u8* paletteBase = vdp2FontPalettes + paletteIndex * 32;
+
+    int r0 = bodyColor & 0x1F;
+    int g0 = (bodyColor >> 5) & 0x1F;
+    int b0 = (bodyColor >> 10) & 0x1F;
+    int r1 = borderColor & 0x1F;
+    int g1 = (borderColor >> 5) & 0x1F;
+    int b1 = (borderColor >> 10) & 0x1F;
+
+    for (int i = 0; i < 16; i++)
+    {
+        u16 color;
+        if (i == 0)
+        {
+            color = 0x0000;
+        }
+        else if (i <= 7)
+        {
+            color = borderColor;
+        }
+        else
+        {
+            int t = i - 8;
+            int r = r0 + (r1 - r0) * t / 7;
+            int g = g0 + (g1 - g0) * t / 7;
+            int b = b0 + (b1 - b0) * t / 7;
+            color = (u16)((b << 10) | (g << 5) | r);
+        }
+
+        paletteBase[i * 2] = (color >> 8) & 0xFF;
+        paletteBase[i * 2 + 1] = color & 0xFF;
+    }
 }
 
 void setFontDefaultColors()
 {
+    copyFontToVdp2();
+
+    setFontDefaultColor(0, 0x4210, 0x0000);
     setFontDefaultColor(7, 0xF03C, 0x8421);
     setFontDefaultColor(8, 0xEB47, 0x8421);
     setFontDefaultColor(9, 0xA368, 0x8421);
@@ -957,7 +1027,7 @@ void setFontDefaultColors()
     setFontDefaultColor(13, 0x875A, 0x8421);
     setFontDefaultColor(14, 0xB18C, 0x8421);
 
-    copyFontToVdp2();
+    setFontDefaultColor(15, 0x4210, 0x0000);
 }
 
 std::array<sVdpVar1, 14> vdpVar1;
@@ -1507,7 +1577,7 @@ void moveVdp2TextCursor(s_stringStatusQuery* vars)
 }
 
 u32 printVdp2StringTable[10] = {
-    12, 13, 7, 8, 9, 10, 11, 13, 7, 14
+    0, 13, 7, 8, 9, 10, 11, 13, 7, 14
 };
 
 void printVdp2StringNewLine(s_stringStatusQuery* vars)

--- a/AzelLib/o_title.cpp
+++ b/AzelLib/o_title.cpp
@@ -1,6 +1,9 @@
 #include "PDS.h"
 #include "audio/soundDriver.h"
 
+void loadFont();
+void setFontPaletteGradient(u32 paletteIndex, u16 bodyColor, u16 borderColor);
+
 namespace TITLE_OVERLAY {
 
 struct s_titleOverlayWorkArea : public s_workAreaTemplate<s_titleOverlayWorkArea>
@@ -108,6 +111,7 @@ sLayerConfig titleNBG1Setup[] =
 void loadTitleScreenGraphics()
 {
     reinitVdp2();
+    ::loadFont();
 
     vdp2Controls.m4_pendingVdp2Regs->m0_TVMD = (vdp2Controls.m4_pendingVdp2Regs->m0_TVMD & 0xFFF8) | 3; // HRESO 704
     vdp2Controls.m4_pendingVdp2Regs->m0_TVMD = (vdp2Controls.m4_pendingVdp2Regs->m0_TVMD & 0xFF3F) | 0xC0; // LSMD0 & 1 to 1 (double density interlace)
@@ -115,11 +119,18 @@ void loadTitleScreenGraphics()
 
     loadFile("TITLEE.SCB", getVdp2Vram(0x20000), 0);
     addToMemoryLayout(getVdp2Vram(0x20000), 1);
-
     loadFile("TITLEE.PNB", getVdp2Vram(0x10000), 0);
     addToMemoryLayout(getVdp2Vram(0x10000), 1);
 
     asyncDmaCopy(titleScreenPalette, getVdp2Cram(0), 0x200, 0);
+    asyncDmaCopy(titleScreenPalette, getVdp2Cram(0xE00), 0x200, 0);
+
+    // Override text palettes at CRAM 0xE00 after background palette copy
+    // Uses setFontPaletteGradient which writes full gradient (entries 8-15)
+    setFontPaletteGradient(9,  0x03E0, 0x0120);  // arrows: green gradient
+    setFontPaletteGradient(12, 0xEF7B, 0x8421);  // menu text: white gradient
+    setFontPaletteGradient(13, 0xEF7B, 0x8421);  // "PRESS START BUTTON": white gradient
+
 
     vdp2Controls.m4_pendingVdp2Regs->m10_CYCA0 = 0x15FFFFF;
     vdp2Controls.m4_pendingVdp2Regs->m14_CYCA1 = 0x44FFFFF;
@@ -157,6 +168,8 @@ void s_titleOverlayWorkArea::titleOverlay_Update(s_titleOverlayWorkArea* pWorkAr
         loadTitleScreenGraphics();
         loadSoundBanks(0x4B, 0);
         pWorkArea->m_4 = 150;
+        // "PANZER DRAGOON SAGA" subtitle is part of the background art (NBG0)
+        // so skip drawing it again on NBG1
         pWorkArea->m_status++;
     case 1:
         if (!isSoundLoadingFinished())


### PR DESCRIPTION
Fixes the title screen menu text not appearing. The font data and color palettes were not being set up for the text layer.

## Files changed

### Title screen setup
- **AzelLib/o_title.cpp** (L1-3): Add forward declarations for `loadFont()` and `setFontPaletteGradient()`
- **AzelLib/o_title.cpp** (L112-114): Call `loadFont()` after VDP2 reinit so the text layer has character data in VRAM
- **AzelLib/o_title.cpp** (L137-144): Copy background palette to CRAM 0xE00 (where the font palettes live), then set up specific text colors:
  - Palette 9: green gradient for menu arrows
  - Palette 12: white gradient for menu item text
  - Palette 13: white gradient for "PRESS START BUTTON"
- **AzelLib/o_title.cpp** (L179-180): Skip drawing "PANZER DRAGOON SAGA" subtitle on text layer (it is already part of the background art)

### Font palette generation
- **AzelLib/VDP2.cpp** `setFontDefaultColor()` (L976-1010): Implement function body (was empty). Generates a 16-entry palette with transparent background (entry 0), border color (entries 1-7), and a gradient from body to border color (entries 8-15)
- **AzelLib/VDP2.cpp** (L1012-1052): Add new `setFontPaletteGradient()` function for title-specific palette overrides
- **AzelLib/VDP2.cpp** `setFontDefaultColors()` (L1055-1072): Move `copyFontToVdp2()` to run first (before setting palette entries), add palette 0 and 15 (grey text with black border)
- **AzelLib/VDP2.cpp** (L1634): Change `printVdp2StringTable[0]` from palette 12 to palette 0 so default text uses the correct color

## Merge note
Code works on its own and won't break anything. However, the text will only be visible on screen after PR 3 (VDP2 rendering fixes) is also merged, since that PR fixes the background layer rendering that displays the text. Best reviewed after PR 3.